### PR TITLE
Add missing poison to negative spell crit damage augments in dino crafting

### DIFF
--- a/Output/DataFiles/Augments/DinosaurBone.Augments.xml
+++ b/Output/DataFiles/Augments/DinosaurBone.Augments.xml
@@ -429,7 +429,7 @@ Evil damage.</Description>
   </Augment>
   <Augment>
     <Name>Scale: Negative Spell Critical Damage</Name>
-    <Description>+20% Enhancement bonus to Negative Spell Critical Damage</Description>
+    <Description>+20% Enhancement bonus to Negative and Poison Spell Critical Damage</Description>
     <MinLevel>31</MinLevel>
     <Type>IoD: Accessory: Scale Slot</Type>
     <Type>IoD: Accessory: Artifact Scale Slot</Type>
@@ -440,6 +440,13 @@ Evil damage.</Description>
       <AType>Simple</AType>
       <Amount size="1">20</Amount>
       <Item>Negative</Item>
+    </Effect>
+    <Effect>
+      <Type>SpellCriticalDamage</Type>
+      <Bonus>Enhancement</Bonus>
+      <AType>Simple</AType>
+      <Amount size="1">20</Amount>
+      <Item>Poison</Item>
     </Effect>
   </Augment>
   <Augment>
@@ -842,7 +849,7 @@ sneak attack.</Description>
   </Augment>
   <Augment>
     <Name>Fang: Negative Spell Critical Damage</Name>
-    <Description>+10 Insightful bonus to Negative spell critical damage</Description>
+    <Description>+10 Insightful bonus to Negative and Poison spell critical damage</Description>
     <MinLevel>31</MinLevel>
     <Type>IoD: Accessory: Fang Slot</Type>
     <Type>IoD: Accessory: Artifact Fang Slot</Type>
@@ -853,6 +860,13 @@ sneak attack.</Description>
       <AType>Simple</AType>
       <Amount size="1">10</Amount>
       <Item>Negative</Item>
+    </Effect>
+    <Effect>
+      <Type>SpellCriticalDamage</Type>
+      <Bonus>Insightful</Bonus>
+      <AType>Simple</AType>
+      <Amount size="1">10</Amount>
+      <Item>Poison</Item>
     </Effect>
   </Augment>
   <Augment>
@@ -978,7 +992,7 @@ sneak attack.</Description>
   </Augment>
   <Augment>
     <Name>Claw: Negative Spell Critical Damage</Name>
-    <Description>+5% Quality bonus to Negative spell critical damage</Description>
+    <Description>+5% Quality bonus to Negative and Poison spell critical damage</Description>
     <MinLevel>31</MinLevel>
     <Type>IoD: Accessory: Claw Slot</Type>
     <Type>IoD: Accessory: Artifact Claw Slot</Type>
@@ -989,6 +1003,13 @@ sneak attack.</Description>
       <AType>Simple</AType>
       <Amount size="1">5</Amount>
       <Item>Negative</Item>
+    </Effect>
+    <Effect>
+      <Type>SpellCriticalDamage</Type>
+      <Bonus>Quality</Bonus>
+      <AType>Simple</AType>
+      <Amount size="1">5</Amount>
+      <Item>Poison</Item>
     </Effect>
   </Augment>
   <Augment>


### PR DESCRIPTION
See picture.

![image](https://github.com/Maetrim/DDOBuilderV2/assets/82330234/7bce6749-a527-4507-a42d-6517e6db3d50)
