### PR TITLE
 Fixed cost of Tabaxi Trailblazer T4's Fast Sprinter

### DIFF
--- a/Output/DataFiles/EnhancementTrees/TabaxiTrailblazer.tree.xml
+++ b/Output/DataFiles/EnhancementTrees/TabaxiTrailblazer.tree.xml
@@ -632,7 +632,7 @@ all enemies Spring Attack hits. This damage scales with 200% Melee Power.</Descr
        <Icon>TabTrailFastSprinter</Icon>
        <XPosition>3</XPosition>
       <YPosition>4</YPosition>
-      <CostPerRank size="1">2</CostPerRank>
+      <CostPerRank size="1">1</CostPerRank>
       <Ranks>1</Ranks>
       <MinSpent>15</MinSpent>
        <Requirements>


### PR DESCRIPTION
Adjusted cost of Fast Sprinter from Tabaxi Trailblazer T4 to match in-game cost.

I was unable to build the project on my PC, so this needs tested before merging in. Let me know if any other files need edited to fix this (or if there's a something needed to build, was getting errors in VS 2019).